### PR TITLE
Only run the update-readme step on PR merged (and on workflow-dispatch)

### DIFF
--- a/.github/workflows/readme-stars.yml
+++ b/.github/workflows/readme-stars.yml
@@ -1,12 +1,14 @@
 name: Update readme ⭐️ progress
 
 on:
-    schedule:
-        - cron: "51 */4 * * *" # Every 4 hours
     workflow_dispatch:
+    pull_request:
+        types:
+            - closed
 
 jobs:
     update-readme:
+        if: github.event.pull_request.merged == true
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
I saw an update to the template repo that mentioned everyone running the cron at the same time was breaking it so they requested people change the minute on the schedule. I don't really want it scheduled, I'd rather it ran when I update anyway. And I like having PRs in the history for each day anyway.